### PR TITLE
Enable the Menu Trail By Path module in the full profile

### DIFF
--- a/src/cambridge/cambridge.info
+++ b/src/cambridge/cambridge.info
@@ -39,6 +39,7 @@ dependencies[] = media
 dependencies[] = menu_block
 dependencies[] = menu_firstchild
 dependencies[] = menu_force
+dependencies[] = menu_trail_by_path
 dependencies[] = pathauto
 dependencies[] = raven
 dependencies[] = realname

--- a/src/cambridge/cambridge.install
+++ b/src/cambridge/cambridge.install
@@ -77,6 +77,9 @@ function cambridge_install() {
   variable_set('pathauto_node_news_article_pattern', 'news/[node:title]');
   variable_set('pathauto_node_questions_and_answers_pattern', '[node:menu-link:parent:url:path]/[node:title]');
 
+  // Don't let Menu Trail By Path handle breadcrumbs.
+  variable_set('menu_trail_by_path_breadcrumb_handling', FALSE);
+
   // Use the media module for image field instances.
 
   $instances = array(
@@ -216,4 +219,21 @@ function cambridge_install() {
       ->condition('name', $name)
       ->execute();
   }
+}
+
+/**
+ * Set up the Menu Trail By Path module.
+ */
+function cambridge_update_7100() {
+  if (module_exists('menu_trail_by_path') || module_exists('menu_position')) {
+    return;
+  }
+
+  $result = module_enable(array('menu_trail_by_path'));
+
+  if (!$result) {
+    throw new DrupalUpdateException('Failed to enabled Menu Trail By Path module');
+  }
+
+  variable_set('menu_trail_by_path_breadcrumb_handling', FALSE);
 }

--- a/src/cambridge/cambridge.make
+++ b/src/cambridge/cambridge.make
@@ -41,6 +41,7 @@ projects[memcache][patch][] = "http://drupal.org/files/memcache-missing-extensio
 projects[memcache][patch][] = "http://drupal.org/files/memcache-display-connection-error-1830496-6.patch"
 projects[menu_admin_per_menu] = "1.0"
 projects[menu_force] = "1.2"
+projects[menu_trail_by_path] = "2.0"
 projects[nodequeue] = "2.0-beta1"
 projects[pathologic] = "2.12"
 projects[realname] = "1.1"


### PR DESCRIPTION
When looking at a node which isn't in the menu (eg a news article), the natural parent item isn't marked as active (eg the News view). This enables the [Menu Trail By Path](https://drupal.org/project/menu_trail_by_path) module in the full profile which handles this.
