### PR TITLE
Disable node previews

### DIFF
--- a/src/cambridge/cambridge.install
+++ b/src/cambridge/cambridge.install
@@ -23,11 +23,17 @@ function cambridge_install() {
   // News articles shouldn't be promoted to front page.
   variable_set('node_options_news_article', array('status'));
 
+  // Disable previewing on news articles.
+  variable_set('node_preview_news_article', DRUPAL_DISABLED);
+
   // Display date and author information on news articles.
   variable_set('node_submitted_news_article', TRUE);
 
   // News articles shouldn't be on a menu.
   variable_set('menu_options_news_article', array());
+
+  // Disable previewing on questions and answers pages.
+  variable_set('node_preview_questions_and_answers', DRUPAL_DISABLED);
 
   $instances = array(
     array(

--- a/src/cambridge_base.inc
+++ b/src/cambridge_base.inc
@@ -123,6 +123,9 @@ function cambridge_base_install() {
     // Not promoted to front page.
     variable_set('node_options_' . $type->type, array('status'));
 
+    // Disable previewing.
+    variable_set('node_preview_' . $type->type, DRUPAL_DISABLED);
+
     // Don't display date and author information.
     variable_set('node_submitted_' . $type->type, FALSE);
   }


### PR DESCRIPTION
Drupal's preview button on nodes leaves a lot to be desired, so by default it would be useful to turn it off.

Note this doesn't touch existing sites.