### PR TITLE
1.7.3

### DIFF
--- a/src/cambridge/CHANGELOG.md
+++ b/src/cambridge/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+7.x-1.7.3
+
+19 January 2017
+
+Re-added a patched version of Workbench Moderation [1.4] (https://github.com/JeebsUK/drupal-workbench-moderation/releases/tag/1.4) to solve issues with viewing current drafts. This is being hosted on GitHub.
+
+
 7.x-1.7.2
 
 6 January 2017

--- a/src/cambridge/cambridge.info
+++ b/src/cambridge/cambridge.info
@@ -1,6 +1,6 @@
 name = "University of Cambridge"
 description = "Install the standard University of Cambridge features."
-version = 7.x-1.7.2
+version = 7.x-1.7.3
 core = 7.x
 
 ; core

--- a/src/cambridge/cambridge.make
+++ b/src/cambridge/cambridge.make
@@ -115,8 +115,16 @@ projects[webform_conditional] = "1.2"
 projects[workbench] = "1.2"
 projects[workbench_access] = "1.4"
 projects[workbench_media] = "1.1"
-projects[workbench_moderation][version] = "1.4"
-projects[workbench_moderation][patch][] = "http://www.drupal.org/files/issues/workbench_moderation-fix_callback_argument-1838640-23.patch"
+
+projects[workbench_moderation][type] = "module"
+projects[workbench_moderation][download][type] = "file"
+projects[workbench_moderation][download][url] = "https://github.com/JeebsUK/drupal-workbench-moderation/archive/1.4.tar.gz"
+projects[workbench_moderation][subdir] = "contrib"
+
+
+
+
+
 projects[xmlsitemap] = "2.3"
 
 ; features

--- a/src/cambridge_lite/CHANGELOG.md
+++ b/src/cambridge_lite/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+7.x-1.7.3
+
+19 January 2017
+
+No changes. Changes in this release are only in the full version of the Profile.
+
+
 7.x-1.7.2
 
 6 January 2017

--- a/src/cambridge_lite/cambridge_lite.info
+++ b/src/cambridge_lite/cambridge_lite.info
@@ -1,6 +1,6 @@
 name = "University of Cambridge (lite)"
 description = "Install the core University of Cambridge features."
-version = 7.x-1.7.2
+version = 7.x-1.7.3
 core = 7.x
 
 ; core


### PR DESCRIPTION
Re-added patched version of workbench moderation to solve problems seeing current live version vs current draft on nodes.